### PR TITLE
Test CI with new repo name

### DIFF
--- a/logilica_cli/__main__.py
+++ b/logilica_cli/__main__.py
@@ -8,16 +8,18 @@ from jsonschema import ValidationError
 import yaml
 
 from logilica_cli import sort_click_command_parameters
+from logilica_cli.configuration_schema import validate_configuration
 from logilica_cli.data_sources import data_sources
 from logilica_cli.weekly_report import weekly_report
-from logilica_cli.configuration_schema import validate_configuration
 
 # Default values for command options
 DEFAULT_CONFIG_FILE = "./logilica-cli.yaml"
 DEFAULT_OUTPUT_DIR = "./output"
 
 # Set up logging and create the Bottle application
-logging.basicConfig(format="[%(levelname)s] logilica-cli: %(message)s", level=logging.WARNING)
+logging.basicConfig(
+    format="[%(levelname)s] logilica-cli: %(message)s", level=logging.WARNING
+)
 
 
 @sort_click_command_parameters


### PR DESCRIPTION
Since the CI includes a reference to the repository by name, renaming the repository and correcting the reference presents a chicken-and-egg challenge.  Cleaving that Gordian Knot, we simply merged #25 without a successful CI run.  (Tragically, if we had renamed the repo _first_, then we could have run the CI on the PR or at least on the resulting `main` and seen it (try to) work, but I did the merge first and so the CI run on `main` failed, and so here we are.)

"Happily", working on the next change, I noticed that the CI should have failed on the previous PR during the lint pass, so this PR addresses that **_and_** gives us an opportunity to test the new configuration.  😉 